### PR TITLE
Make backward-compatible with Python version prior to 2.7

### DIFF
--- a/edx-dl-5.py
+++ b/edx-dl-5.py
@@ -36,7 +36,7 @@ post_data = urllib.urlencode({
             }).encode('utf-8')
 request = urllib2.Request(LOGIN_API, post_data,headers)
 response = urllib2.urlopen(request)
-resp = json.loads(response.read().decode(encoding = 'utf-8'))
+resp = json.loads(response.read().decode('utf-8'))
 if not resp.get('success', False):
     print 'Wrong Email or Password.'
     exit(2)

--- a/edx-dl.py
+++ b/edx-dl.py
@@ -36,7 +36,7 @@ post_data = urllib.urlencode({
             }).encode('utf-8')
 request = urllib2.Request(LOGIN_API, post_data,headers)
 response = urllib2.urlopen(request)
-resp = json.loads(response.read().decode(encoding = 'utf-8'))
+resp = json.loads(response.read().decode('utf-8'))
 if not resp.get('success', False):
     print 'Wrong Email or Password.'
     exit(2)


### PR DESCRIPTION
Make backward-compatible with Python version prior to 2.7 which does not support keyword arguments.

Python Documentation: http://docs.python.org/2/library/stdtypes.html#str.decode

Patch: https://github.com/dumpweed/edx-downloader/commit/2b923e6727bbe9950d3ff3a8b85cabe5d7408d7f
