### PR TITLE
fix for extracting list of courses

### DIFF
--- a/edx-dl.py
+++ b/edx-dl.py
@@ -49,7 +49,7 @@ soup = BeautifulSoup(dash)
 data = soup.find_all('ul')[1]
 USERNAME =  data.find_all('span')[1].string
 USEREMAIL = data.find_all('span')[3].string
-COURSES = soup.find_all('article')
+COURSES = soup.find_all('article','my-course')
 courses = []
 for COURSE in COURSES :
     c_name = COURSE.h3.string


### PR DESCRIPTION
Currently the article tag is also used for things that are not courses,
which breaks the rest of the script. Narrowing things down by only grabbing articles with the class "my-course" fixes the problem.
