### PR TITLE
Fixed download of new courses where speed video has more decimals

### DIFF
--- a/edx-dl.py
+++ b/edx-dl.py
@@ -174,7 +174,7 @@ if __name__ == '__main__':
     for link in links:
         print("Processing '%s'..." % link)
         page = get_page_contents(link, headers)
-        splitter = re.compile(b'data-streams=(?:&#34;|").*1.0:')
+        splitter = re.compile(b'data-streams=(?:&#34;|").*1.0[0]*:')
         id_container = splitter.split(page)[1:]
         video_id += [link[:YOUTUBE_VIDEO_ID_LENGTH] for link in
                      id_container]


### PR DESCRIPTION
1.00:... and not 1.0: as normally used.
This allows to download 7.00x
