### PR TITLE
Fix issue #20

### DIFF
--- a/edx-dl.py
+++ b/edx-dl.py
@@ -141,7 +141,9 @@ if __name__ == '__main__':
     ## Getting Available Weeks
     courseware = get_page_contents(COURSEWARE, headers)
     soup = BeautifulSoup(courseware)
-    data = soup.section.section.div.div.nav
+
+    data = soup.find("section",
+                     {"class": "content-wrapper"}).section.div.div.nav
     WEEKS = data.find_all('div')
     weeks = [(w.h3.a.string, ['https://www.edx.org' + a['href'] for a in
              w.ul.find_all('a')]) for w in WEEKS]


### PR DESCRIPTION
Yes, there was a problem due to some changes in the edx page (the new calc and help gadgets). Now it looks the correct section by class name.
I just fixed it in this pull request.
