### PR TITLE
Output UTF8 by default

### DIFF
--- a/edx-dl.py
+++ b/edx-dl.py
@@ -282,6 +282,10 @@ def main():
 
 if __name__ == '__main__':
     try:
+        if hasattr(sys.stdout, 'detach'):
+            sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())
+        else:
+            sys.stdout = codecs.getwriter("utf-8")(sys.stdout)
         main()
     except KeyboardInterrupt :
         print("\n\nCTRL-C detected, shutting down....")


### PR DESCRIPTION
Error messages were generated when outputting to a console whose default encoding is not UTF8. This was easy to notice if your name has non-ASCII characters (like the "ă" in my name).

This change makes the script write UTF8 to stdout by default. The text will appear slightly garbled if the default encoding is not UTF8 (most famously, in the Windows Console), but at least it won't crash.
