### PR TITLE
Fixes #66 defaults preference to the best mp4 available when the format … isn't available

### DIFF
--- a/edx-dl.py
+++ b/edx-dl.py
@@ -365,7 +365,7 @@ def get_filename(target_dir, filename_prefix):
     # this whole function is not the nicest thing, but isolating it makes
     # things clearer , a good refactoring would be to get
     # the info from the video_url or the current output, to avoid the
-    # iteration from the current dirœ
+    # iteration from the current dir
     filenames = os.listdir(target_dir)
     subs_filename = filename_prefix
     for name in filenames:  # Find the filename of the downloaded video


### PR DESCRIPTION
I think this is probably the easiest approach to this problem, notice that I changed format to be a string since youtube supports '-f mp4' or '-f flv' as options. Also you can put different preferences and it will download the best available e.g. '135/15/mp4'.
The alternative would be to check the output code of youtube-dl and then re-execute the command which I think would add innecesary complexity to the script.
