### PR TITLE
Overload print function to filter out unprintable characters especially for the encoding bug of Windows console

### DIFF
--- a/edx-dl.py
+++ b/edx-dl.py
@@ -86,6 +86,8 @@ def print(*objects, **kwargs):
         if stream is None:
             stream = sys.stdout
         enc = stream.encoding
+        if enc is None:
+            enc = sys.getdefaultencoding()
     except AttributeError:
         return __builtins__.print(*objects, **kwargs)
     texts = []


### PR DESCRIPTION
This patch is an alternative implementation of #55.
While the old one requires to use a customed print function, this patch replaces the function.
It might solve #81.
