### PR TITLE
Promote good password handling practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ the simplest is to simply use:
 Once you have installed everything, to use `edx-dl.py`, let it discover the
 courses in which you are enrolled, by issuing:
 
-    python edx-dl.py -u user@user.com -p password --list-courses
+    python edx-dl.py -u user@user.com --list-courses
 
 From there, choose the course you are interested in, copy its URL and use it
 in the following command:
 
-    python edx-dl.py -u user@user.com -p password COURSE_URL
+    python edx-dl.py -u user@user.com COURSE_URL
 
 replacing `COURSE_URL` with the URL that you just copied in the first step.
 It should look something like:

--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -227,7 +227,8 @@ def parse_args():
     parser.add_argument('-p',
                         '--password',
                         action='store',
-                        help='your edX password')
+                        help='your edX password, '
+                        'beware: it might be visible to other users on your system')
 
     parser.add_argument('-f',
                         '--format',


### PR DESCRIPTION
As a follow-up to #255 I would like to contribute an updated `README.md` and help for the `--password` command line option. From my point of view it is a good practice not using potentially risky options in quick start examples and to warn the users in the help for this option.

Tests pass, except
```
test_utils.py::test_execute_command_should_succeed SKIPPED
test_utils.py::test_execute_command_should_fail SKIPPED
```
which were skipped on my system.