### PR TITLE
Do not use reason field of URLError exception (fix #251)

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -177,7 +177,7 @@ def edx_get_subtitle(url, headers):
         json_object = get_page_contents_as_json(url, headers)
         return edx_json2srt(json_object)
     except URLError as exception:
-        logging.warn('edX subtitles (error: %s)', exception.reason)
+        logging.warn('edX subtitles (error: %s)', exception)
         return None
     except ValueError as exception:
         logging.warn('edX subtitles (error: %s)', exception.message)


### PR DESCRIPTION
In the code we catch URLError exception. Users, however,
sometimes get HTTPError exception which is a subclass of
URLError. In certain versions of Python, HTTPError does
not have reason field. According to the documentation,
at least version 2.6 lacks it:

https://docs.python.org/2.6/library/urllib2.html#urllib2.HTTPError

A very common and simple solution is to simply format the
whole exception into a string.