### PR TITLE
edx_dl/common: Use comments on the classes as the module docstring.

### DIFF
--- a/edx_dl/common.py
+++ b/edx_dl/common.py
@@ -2,37 +2,36 @@
 
 """
 Common type definitions and constants for edx-dl
+
+The classes in this module represent the structure of courses in edX.  The
+structure is:
+
+* A Course contains Sections
+* Each Section contains Subsections
+* Each Subsection contains Units
+
+Notice that we don't represent the full tree structure for both performance
+and UX reasons:
+
+Course ->  [Section] -> [SubSection] -> [Unit] -> [Video]
+
+In the script the data structures used are:
+
+1. The data structures to represent the course information:
+   Course, Section->[SubSection]
+
+2. The data structures to represent the chosen courses and sections:
+   selections = {Course, [Section]}
+
+3. The data structure of all the downloable resources which represent each
+   subsection via its URL and the of resources who can be extracted from the
+   Units it contains:
+   all_units = {Subsection.url: [Unit]}
+
+4. The units can contain multiple videos:
+   Unit -> [Video]
 """
 
-
-# The next four classes represent the structure of courses in edX.  The
-# structure is:
-#
-# * A Course contains Sections
-# * Each Section contains Subsections
-# * Each Subsection contains Units
-#
-# Notice that we don't represent the full tree structure for both performance
-# and UX reasons:
-#
-# Course ->  [Section] -> [SubSection] -> [Unit] -> [Video]
-#
-# In the script the data structures used are:
-#
-# 1. The data structures to represent the course information:
-#    Course, Section->[SubSection]
-#
-# 2. The data structures to represent the chosen courses and sections:
-#    selections = {Course, [Section]}
-#
-# 3. The data structure of all the downloable resources which represent each
-#    subsection via its URL and the of resources who can be extracted from the
-#    Units it contains:
-#    all_units = {Subsection.url: [Unit]}
-#
-# 4. The units can contain multiple videos:
-#    Unit -> [Video]
-#
 
 class Course(object):
     """


### PR DESCRIPTION
The huge comment that we have is better if it is made part of the docstring
of the module, as that is informative when using pydoc (or any other kind of
documentation browser that one wishes to use).

In fact, I would argue that it is even going to be nice to have it become
"part of our API" (for the lack of a better term), as I believe that it will
bring us more flexibility.

Signed-off-by: Rogério Brito <rbrito@ime.usp.br>