### PR TITLE
Use named constants for exit code values

### DIFF
--- a/edx_dl/common.py
+++ b/edx_dl/common.py
@@ -151,5 +151,18 @@ class Video(object):
         self.mp4_urls = mp4_urls
 
 
+class ExitCode(object):
+    """
+    Class that contains all exit codes of the program.
+    """
+    OK = 0
+    MISSING_CREDENTIALS = 1
+    WRONG_EMAIL_OR_PASSWORD = 2
+    MISSING_COURSE_URL = 3
+    INVALID_COURSE_URL = 4
+    UNKNOWN_PLATFORM = 5
+    NO_DOWNLOADABLE_VIDEO = 6
+
+
 YOUTUBE_DL_CMD = ['youtube-dl', '--ignore-config']
 DEFAULT_CACHE_FILENAME = 'edx-dl.cache'


### PR DESCRIPTION
This way we have all exit codes in one place, which is useful if we
consider writing a man page.

Please pay attention that after the message `logging.error("OpenEdX platform should be one of: %s", ', '.join(sites))`, there was `exit(2)`, which I replaced with `exit(ExitCode.UNKNOWN_PLATFORM)`, so it's `exit(5)` now. The code `2` was used in two different error cases, I fixed this. Please check that my understanding is correct.