### PR TITLE
Support for BITS edx site added

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -79,6 +79,10 @@ OPENEDX_SITES = {
         'url': 'https://mitprofessionalx.mit.edu',
         'courseware-selector': ('nav', {'aria-label': 'Course Navigation'}),
     },
+    'bits':{
+        'url':'http://any-learn.bits-pilani.ac.in',
+        'courseware-selector': ('nav', {'aria-label': 'Course Navigation'}),  
+    }
 }
 BASE_URL = OPENEDX_SITES['edx']['url']
 EDX_HOMEPAGE = BASE_URL + '/login_ajax'


### PR DESCRIPTION
Support for edX MOOC portal hosted for courses conducted in BITS Pilani.

Changes were to add the portal details to the set of supported sites.