### PR TITLE
edx_dl/edx_dl: Dirty, WIP, not-to-be merged use of external downloader.

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -620,6 +620,14 @@ def download_url(url, filename, headers, args):
     if is_youtube_url(url):
         download_youtube_url(url, filename, headers, args)
     else:
+
+        cmd = ['aria2c', '-o', filename, '--check-certificate=false',
+               '--log-level=notice',
+               '--max-connection-per-server=4', '--min-split-size=1M', url]
+
+        execute_command(cmd, args)
+        return
+
         import ssl
         # FIXME: Ugly hack for coping with broken SSL sites:
         # https://www.cs.duke.edu/~angl/papers/imc10-cloudcmp.pdf


### PR DESCRIPTION
I'm getting tired of fighting with Python's SSL errors for my own use (and
the users are probably also getting so, if they have stumbled on as many
problems as I did).

Signed-off-by: Rogério Brito <rbrito@ime.usp.br>