### PR TITLE
Add hint on how to ignore HTTP errors when they occur (fix #316)

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -647,6 +647,8 @@ def download_url(url, filename, headers, args):
         except Exception as e:
             logging.warn('Got SSL/Connection error: %s', e)
             if not args.ignore_errors:
+                logging.warn('Hint: if you want to ignore this error, add '
+                             '--ignore-errors option to the command line')
                 raise e
             else:
                 logging.warn('SSL/Connection error ignored: %s', e)


### PR DESCRIPTION
It took me several minutes to figure out that HTTP 404 could be easily
ignored. That hint will hopefully allow us to not forget about that
option. Attentive users that read logs may benefit from that too.