### PR TITLE
Stanford video and subtitle download: issue #327

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -698,7 +698,7 @@ def skip_or_download(downloads, headers, args, f=download_url):
 
 
 def download_video(video, args, target_dir, filename_prefix, headers):
-    if args.prefer_cdn_videos:
+    if args.prefer_cdn_videos or video.video_youtube_url is None:
         mp4_downloads = _build_url_downloads(video.mp4_urls, target_dir,
                                              filename_prefix)
         skip_or_download(mp4_downloads, headers, args)

--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -178,7 +178,7 @@ def get_available_sections(url, headers):
     return sections
 
 
-def edx_get_subtitle(url, headers):
+def edx_get_subtitle(url, headers, get_page_contents=get_page_contents, get_page_contents_as_json=get_page_contents_as_json):
     """
     Return a string with the subtitles content from the url or None if no
     subtitles are available.

--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -184,8 +184,11 @@ def edx_get_subtitle(url, headers):
     subtitles are available.
     """
     try:
-        json_object = get_page_contents_as_json(url, headers)
-        return edx_json2srt(json_object)
+        if ';' in url:  # non-JSON format (e.g. Stanford)
+            return get_page_contents(url, headers)
+        else:
+            json_object = get_page_contents_as_json(url, headers)
+            return edx_json2srt(json_object)
     except URLError as exception:
         logging.warn('edX subtitles (error: %s)', exception)
         return None
@@ -557,6 +560,15 @@ def get_subtitles_urls(available_subs_url, sub_template_url, headers):
 
         return {sub_lang: sub_template_url % sub_lang
                 for sub_lang in available_subs}
+
+    elif sub_template_url is not None:
+        try:
+            available_subs = get_page_contents(sub_template_url,
+                                                       headers)
+        except HTTPError:
+            available_subs = ['en']
+
+        return {'en': sub_template_url}
 
     return {}
 

--- a/edx_dl/parsing.py
+++ b/edx_dl/parsing.py
@@ -141,6 +141,13 @@ class ClassicEdXPageExtractor(PageExtractor):
                 available_subs_url = BASE_URL + match_available_subs.group(1)
                 sub_template_url = BASE_URL + match_subs.group(1) + "/%s"
 
+        else:
+            re_available_subs_url=re.compile(r'href=(?:&#34;|")([^"&]+)(?:&#34;|")&gt;Download transcript&lt;')
+            match_available_subs = re_available_subs_url.search(text)
+            if match_available_subs:
+                sub_template_url = BASE_URL + match_available_subs.group(1)
+                available_subs_url = None
+
         return available_subs_url, sub_template_url
 
     def extract_mp4_urls(self, text):

--- a/test_edx_dl.py
+++ b/test_edx_dl.py
@@ -85,3 +85,34 @@ def test_extract_urls_from_units_unknown_videos(unknown_videos):
     """
     with pytest.raises(TypeError):
         edx_dl.extract_urls_from_units(unknown_videos, '%(url)s')
+
+
+def test_edx_get_subtitle():
+    """
+    Make sure Stanford subtitle URLs are distinguished from EdX ones.
+    """
+
+    def mock_get_page_contents(u, h):
+        assert u == url
+        assert h == headers
+        return u
+    
+    def mock_get_page_contents_as_json(u, h):
+        assert u == url
+        assert h == headers
+        return { 'start' : [123], 'end' : [456], 'text' : ["subtitle content"] }
+
+    url = "https://lagunita.stanford.edu/courses/Engineering/QMSE02./Winter2016/xblock/i4x:;_;_Engineering;_QMSE02.;_video;_7f4f16e3eb294538aa8db4c43877132b/handler/transcript/download"
+    headers = {}
+    get_page_contents = lambda u, h: u
+    
+    expected = url
+    actual = edx_dl.edx_get_subtitle(url, headers, mock_get_page_contents, mock_get_page_contents_as_json)
+    assert expected == actual
+
+    # Make sure Non-Stanford URLs still work
+    url = "https://www.edx.org/could/be/more/realistic"
+
+    expected = '0\n00:00:00,123 --> 00:00:00,456\nsubtitle content\n\n'
+    actual = edx_dl.edx_get_subtitle(url, headers, mock_get_page_contents, mock_get_page_contents_as_json)
+    assert expected == actual

--- a/test_edx_dl.py
+++ b/test_edx_dl.py
@@ -116,3 +116,35 @@ def test_edx_get_subtitle():
     expected = '0\n00:00:00,123 --> 00:00:00,456\nsubtitle content\n\n'
     actual = edx_dl.edx_get_subtitle(url, headers, mock_get_page_contents, mock_get_page_contents_as_json)
     assert expected == actual
+
+
+def test_extract_subtitle_urls():
+    text = """
+&lt;li class="video-tracks video-download-button"&gt;
+            &lt;a href="/courses/Engineering/QMSE02./Winter2016/xblock/i4x:;_;_Engineering;_QMSE02.;_video;_1a4c7ff41e484a15927987b745a5c779/handler/transcript/download"&gt;Download transcript&lt;/a&gt;
+            &lt;div class="a11y-menu-container"&gt;
+                &lt;a class="a11y-menu-button" href="#" title=".srt" role="button" aria-disabled="false"&gt;.srt&lt;/a&gt;
+                &lt;ol class="a11y-menu-list" role="menu"&gt;
+                  &lt;li class="a11y-menu-item active"&gt;
+                  
+                      &lt;a class="a11y-menu-item-link" href="#srt" title="SubRip (.srt) file" data-value="srt" role="menuitem" aria-disabled="false"&gt;
+                        SubRip (.srt) file
+                      &lt;/a&gt;
+                  &lt;/li&gt;
+                  &lt;li class="a11y-menu-item"&gt;
+                  
+                      &lt;a class="a11y-menu-item-link" href="#txt" title="Text (.txt) file" data-value="txt" role="menuitem" aria-disabled="false"&gt;
+                        Text (.txt) file
+                      &lt;/a&gt;
+                  &lt;/li&gt;
+                &lt;/ol&gt;
+            &lt;/div&gt;
+        &lt;/li&gt;
+    """
+
+    page_extractor = parsing.CurrentEdXPageExtractor()
+    expected = (None, 'https://base.url/courses/Engineering/QMSE02./Winter2016/xblock/i4x:;_;_Engineering;_QMSE02.;_video;_1a4c7ff41e484a15927987b745a5c779/handler/transcript/download')
+    actual = page_extractor.extract_subtitle_urls(text, "https://base.url")
+    print("actual", actual)
+    assert expected == actual
+


### PR DESCRIPTION
This restores the ability to download video and subtitles from Stanford On-Line.  These are in two separate changesets.  The video download was easy.  The subtitles download was harder, because Stanford no longer use JSON objects to describe the available subtitles files.