### PR TITLE
Add new options to support arbitrary file format extraction

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,7 @@
+🚨Please review the [Troubleshooting](../#troubleshooting) section
+before reporting any issue. Don't forget also to check the current issues to
+avoid duplicates.
+
 ### Subject of the issue
 Describe your issue here.
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__/
 /.tox
 /.coverage
 /htmlcov
+.cache/
 
 # Application files
 edx-dl.cache

--- a/edx_dl/common.py
+++ b/edx_dl/common.py
@@ -172,3 +172,6 @@ class ExitCode(object):
 
 YOUTUBE_DL_CMD = ['youtube-dl', '--ignore-config']
 DEFAULT_CACHE_FILENAME = 'edx-dl.cache'
+DEFAULT_FILE_FORMATS = ['e?ps', 'pdf', 'txt', 'doc', 'xls', 'ppt',
+                        'docx', 'xlsx', 'pptx', 'odt', 'ods', 'odp', 'odg',
+                        'zip', 'rar', 'gz', 'mp3']

--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -36,6 +36,7 @@ from .common import (
     Unit,
     Video,
     ExitCode,
+    DEFAULT_FILE_FORMATS,
 )
 from .parsing import (
     edx_json2srt,

--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -329,6 +329,26 @@ def parse_args():
                         'is used. Available variables: %%(url)s. Default: '
                         '"%%(url)s"')
 
+    parser.add_argument('--list-file-formats',
+                        dest='list_file_formats',
+                        action='store_true',
+                        default=False,
+                        help='list the default file formats extracted')
+
+    parser.add_argument('--file-formats',
+                        dest='file_formats',
+                        action='store',
+                        default=None,
+                        help='appends file formats to be extracted (comma '
+                        'separated)')
+
+    parser.add_argument('--overwrite-file-formats',
+                        dest='overwrite_file_formats',
+                        action='store_true',
+                        default=False,
+                        help='if active overwrites the file formats to be '
+                        'extracted')
+
     parser.add_argument('--cache',
                         dest='cache',
                         action='store_true',
@@ -530,6 +550,27 @@ def parse_sections(args, selections):
                            _filter_sections(args.filter_section, selected_sections)
                            for selected_course, selected_sections in selections.items()}
     return filtered_selections
+
+
+def parse_file_formats(args):
+    """
+    parse options for file formats and builds the array to be used
+    """
+    file_formats = DEFAULT_FILE_FORMATS
+
+    if args.list_file_formats:
+        logging.info(file_formats)
+        exit(ExitCode.OK)
+
+    if args.overwrite_file_formats:
+        file_formats = []
+
+    if args.file_formats:
+        new_file_formats = args.file_formats.split(",")
+        file_formats.extend(new_file_formats)
+
+    logging.debug("file_formats: %s", file_formats)
+    return file_formats
 
 
 def _display_selections(selections):
@@ -921,6 +962,7 @@ def main():
     Main program function
     """
     args = parse_args()
+    file_formats = parse_file_formats(args)
 
     change_openedx_site(args.platform)
 

--- a/edx_dl/parsing.py
+++ b/edx_dl/parsing.py
@@ -16,7 +16,6 @@ from .common import Course, Section, SubSection, Unit, Video
 # Force use of bs4 with html5lib
 BeautifulSoup = lambda page: BeautifulSoup_(page, 'html5lib')
 
-
 def edx_json2srt(o):
     """
     Transform the dict 'o' into the srt subtitles format
@@ -59,7 +58,7 @@ class PageExtractor(object):
       >>> ...
     """
 
-    def extract_units_from_html(self, page, BASE_URL):
+    def extract_units_from_html(self, page, BASE_URL, file_formats):
         """
         Method to extract the resources (units) from the given page
         """
@@ -80,11 +79,7 @@ class PageExtractor(object):
 
 class ClassicEdXPageExtractor(PageExtractor):
 
-    DEFAULT_FILE_FORMATS = ['e?ps', 'pdf', 'txt', 'doc', 'xls', 'ppt',
-                            'docx', 'xlsx', 'pptx', 'odt', 'ods', 'odp', 'odg',
-                            'zip', 'rar', 'gz', 'mp3']
-
-    def extract_units_from_html(self, page, BASE_URL):
+    def extract_units_from_html(self, page, BASE_URL, file_formats):
         """
         Extract Units from the html of a subsection webpage as a list of
         resources
@@ -97,12 +92,12 @@ class ClassicEdXPageExtractor(PageExtractor):
         units = []
 
         for unit_html in re_units.findall(page):
-            unit = self.extract_unit(unit_html, BASE_URL)
+            unit = self.extract_unit(unit_html, BASE_URL, file_formats)
             if len(unit.videos) > 0 or len(unit.resources_urls) > 0:
                 units.append(unit)
         return units
 
-    def extract_unit(self, text, BASE_URL):
+    def extract_unit(self, text, BASE_URL, file_formats):
         """
         Parses the <div> of each unit and extracts the urls of its resources
         """
@@ -114,7 +109,8 @@ class ClassicEdXPageExtractor(PageExtractor):
                         sub_template_url=sub_template_url,
                         mp4_urls=mp4_urls)]
 
-        resources_urls = self.extract_resources_urls(text, BASE_URL)
+        resources_urls = self.extract_resources_urls(text, BASE_URL,
+                                                     file_formats)
         return Unit(videos=videos, resources_urls=resources_urls)
 
     def extract_video_youtube_url(self, text):
@@ -164,8 +160,7 @@ class ClassicEdXPageExtractor(PageExtractor):
 
         return mp4_urls
 
-    def extract_resources_urls(self, text, BASE_URL,
-                               file_formats=DEFAULT_FILE_FORMATS):
+    def extract_resources_urls(self, text, BASE_URL, file_formats):
         """
         Extract resources looking for <a> references in the webpage and
         matching the given file formats
@@ -264,7 +259,7 @@ class CurrentEdXPageExtractor(ClassicEdXPageExtractor):
     """
     A new page extractor for the recent changes in layout of edx
     """
-    def extract_unit(self, text, BASE_URL):
+    def extract_unit(self, text, BASE_URL, file_formats):
         re_metadata = re.compile(r'data-metadata=&#39;(.*?)&#39;')
         videos = []
         match_metadatas = re_metadata.findall(text)
@@ -290,7 +285,8 @@ class CurrentEdXPageExtractor(ClassicEdXPageExtractor):
                                 sub_template_url=sub_template_url,
                                 mp4_urls=mp4_urls))
 
-        resources_urls = self.extract_resources_urls(text, BASE_URL)
+        resources_urls = self.extract_resources_urls(text, BASE_URL,
+                                                     file_formats)
         return Unit(videos=videos, resources_urls=resources_urls)
 
     def extract_sections_from_html(self, page, BASE_URL):

--- a/test_edx_dl.py
+++ b/test_edx_dl.py
@@ -3,7 +3,7 @@
 
 import pytest
 from edx_dl import edx_dl, parsing
-from edx_dl.common import Unit, Video
+from edx_dl.common import Unit, Video, DEFAULT_FILE_FORMATS
 
 
 def test_failed_login():
@@ -18,7 +18,9 @@ def test_remove_repeated_urls():
     with open(url, "r") as f:
         html_contents = f.read()
         page_extractor = parsing.CurrentEdXPageExtractor()
-        units_extracted = page_extractor.extract_units_from_html(html_contents, site)
+        units_extracted = page_extractor.extract_units_from_html(html_contents,
+                                                                 site,
+                                                                 DEFAULT_FILE_FORMATS)
 
         all_units = {url: units_extracted}
         filtered_units = edx_dl.remove_repeated_urls(all_units)
@@ -96,7 +98,7 @@ def test_edx_get_subtitle():
         assert u == url
         assert h == headers
         return u
-    
+
     def mock_get_page_contents_as_json(u, h):
         assert u == url
         assert h == headers
@@ -105,7 +107,7 @@ def test_edx_get_subtitle():
     url = "https://lagunita.stanford.edu/courses/Engineering/QMSE02./Winter2016/xblock/i4x:;_;_Engineering;_QMSE02.;_video;_7f4f16e3eb294538aa8db4c43877132b/handler/transcript/download"
     headers = {}
     get_page_contents = lambda u, h: u
-    
+
     expected = url
     actual = edx_dl.edx_get_subtitle(url, headers, mock_get_page_contents, mock_get_page_contents_as_json)
     assert expected == actual
@@ -126,13 +128,13 @@ def test_extract_subtitle_urls():
                 &lt;a class="a11y-menu-button" href="#" title=".srt" role="button" aria-disabled="false"&gt;.srt&lt;/a&gt;
                 &lt;ol class="a11y-menu-list" role="menu"&gt;
                   &lt;li class="a11y-menu-item active"&gt;
-                  
+
                       &lt;a class="a11y-menu-item-link" href="#srt" title="SubRip (.srt) file" data-value="srt" role="menuitem" aria-disabled="false"&gt;
                         SubRip (.srt) file
                       &lt;/a&gt;
                   &lt;/li&gt;
                   &lt;li class="a11y-menu-item"&gt;
-                  
+
                       &lt;a class="a11y-menu-item-link" href="#txt" title="Text (.txt) file" data-value="txt" role="menuitem" aria-disabled="false"&gt;
                         Text (.txt) file
                       &lt;/a&gt;
@@ -147,4 +149,3 @@ def test_extract_subtitle_urls():
     actual = page_extractor.extract_subtitle_urls(text, "https://base.url")
     print("actual", actual)
     assert expected == actual
-

--- a/test_parsing.py
+++ b/test_parsing.py
@@ -7,6 +7,8 @@ import json
 
 import pytest
 
+from edx_dl.common import DEFAULT_FILE_FORMATS
+
 from edx_dl.parsing import (
     edx_json2srt,
     ClassicEdXPageExtractor,
@@ -49,7 +51,9 @@ def test_subtitles_from_json(file, expected):
 def test_extract_units_from_html_single_unit_multiple_subs():
     site = 'https://courses.edx.org'
     with open("test/html/single_unit_multiple_subs.html", "r") as f:
-        units = CurrentEdXPageExtractor().extract_units_from_html(f.read(), site)
+        units = CurrentEdXPageExtractor().extract_units_from_html(f.read(),
+                                                                  site,
+                                                                  DEFAULT_FILE_FORMATS)
 
         assert units[0].videos[0].video_youtube_url == 'https://youtube.com/watch?v=b7xgknqkQk8'
         assert units[0].videos[0].mp4_urls[0] == 'https://d2f1egay8yehza.cloudfront.net/edx-edx101/EDXSPCPJSP13-H010000_100.mp4'
@@ -59,7 +63,9 @@ def test_extract_units_from_html_single_unit_multiple_subs():
 def test_extract_multiple_units_multiple_resources():
     site = 'https://courses.edx.org'
     with open("test/html/multiple_units.html", "r") as f:
-        units = CurrentEdXPageExtractor().extract_units_from_html(f.read(), site)
+        units = CurrentEdXPageExtractor().extract_units_from_html(f.read(),
+                                                                  site,
+                                                                  DEFAULT_FILE_FORMATS)
         assert len(units) == 3
         # this one has multiple speeds in the data-streams field
         assert 'https://youtube.com/watch?v=CJ482b9r_0g' in [video.video_youtube_url for video in units[0].videos]
@@ -71,7 +77,9 @@ def test_extract_multiple_units_multiple_resources():
 def test_extract_multiple_units_no_youtube_ids():
     site = 'https://courses.edx.org'
     with open("test/html/multiple_units_no_youtube_ids.html", "r") as f:
-        units = ClassicEdXPageExtractor().extract_units_from_html(f.read(), site)
+        units = ClassicEdXPageExtractor().extract_units_from_html(f.read(),
+                                                                  site,
+                                                                  DEFAULT_FILE_FORMATS)
         assert units[0].videos[0].video_youtube_url is None
         assert len(units[0].videos[0].mp4_urls) > 0
 
@@ -79,14 +87,18 @@ def test_extract_multiple_units_no_youtube_ids():
 def test_extract_multiple_units_youtube_link():
     site = 'https://courses.edx.org'
     with open("test/html/multiple_units_youtube_link.html", "r") as f:
-        units = CurrentEdXPageExtractor().extract_units_from_html(f.read(), site)
+        units = CurrentEdXPageExtractor().extract_units_from_html(f.read(),
+                                                                  site,
+                                                                  DEFAULT_FILE_FORMATS)
         assert 'https://www.youtube.com/watch?v=5OXQypOAbdI' in units[0].resources_urls
 
 
 def test_extract_multiple_units_multiple_youtube_videos():
     site = 'https://courses.edx.org'
     with open("test/html/multiple_units_multiple_youtube_videos.html", "r") as f:
-        units = CurrentEdXPageExtractor().extract_units_from_html(f.read(), site)
+        units = CurrentEdXPageExtractor().extract_units_from_html(f.read(),
+                                                                  site,
+                                                                  DEFAULT_FILE_FORMATS)
         assert len(units[0].videos) == 3
         assert 'https://youtube.com/watch?v=3atHHNa2UwI' in [video.video_youtube_url for video in units[0].videos]
 


### PR DESCRIPTION
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

## Proposed changes

Currently the file formats extracted during parsing are fixed to some common formats. But it is possible that courses would require particular formats (e.g. java, jar, R, py, etc).

I add three new options to allow this:
--list-file-formats   list the default file formats extracted
--file-formats FILE_FORMATS appends file formats to be extracted (comma separated)
--overwrite-file-formats if active overwrites the file formats to be extracted

This can address the case where videos are not in the metadata but in the html e.g. adding the --file-formats=mp4. See Issue #341

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [x] I have checked the style of the new code (lint/pep).
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I had to refactor some stuff, mostly adding an additional parameter, this can be
further improved but I think the feature is worth the addition as it is, and we can
work on this later on.

### Reviewers
@rbrito can you check this.

