### PR TITLE
Update parsing.py to be compatible with Stanford's lagunita

### DIFF
--- a/edx_dl/parsing.py
+++ b/edx_dl/parsing.py
@@ -342,7 +342,8 @@ def get_page_extractor(url):
     """
     factory method for page extractors
     """
-    if url.startswith('https://courses.edx.org'):
+    if url.startswith('https://courses.edx.org') or url.startswith(
+            'https://lagunita.stanford.edu'):
         return CurrentEdXPageExtractor()
 
     return ClassicEdXPageExtractor()


### PR DESCRIPTION
Since the current main branch doesn't work with the Stanford's lagunita (https://lagunita.stanford.edu) as report in #363. 

After checking source files, I found that the sections_soup variable in parsing.py returns an empty list because the Stanford's lagunita has the new EdX layout. 

Then, I propose to change an if statement in the get_page_extractor to fix the issue:

Current:
if url.startswith('https://courses.edx.org'):
        return CurrentEdXPageExtractor()

Propose:
 if url.startswith('https://courses.edx.org') or url.startswith(
            'https://lagunita.stanford.edu'):

