### PR TITLE
Find youtube videos for some FUN courses

### DIFF
--- a/edx_dl/parsing.py
+++ b/edx_dl/parsing.py
@@ -118,6 +118,10 @@ class ClassicEdXPageExtractor(PageExtractor):
         video_youtube_url = None
         match_video_youtube_url = re_video_youtube_url.search(text)
 
+        if match_video_youtube_url is None:
+            re_video_youtube_url = re.compile(r'https://www.youtube.com/embed/(.{11})\?rel=')
+            match_video_youtube_url = re_video_youtube_url.search(text)
+
         if match_video_youtube_url is not None:
             video_id = match_video_youtube_url.group(1)
             video_youtube_url = 'https://youtube.com/watch?v=' + video_id


### PR DESCRIPTION
## Proposed changes

This adds a new secondary regex to find youtube videos when the first one doesn't match anything. It was however tested on only one course on the FUN platform, where it allows to download the videos (they aren't found else).

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [ ]x I have checked that the unit tests pass locally with my changes
- [ ] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


While trying to download the following course on FUN, I noticed edX-dl didn't download the videos (hosted on youtube):
https://www.fun-mooc.fr/courses/lorraine/30003/session01/info

Upon investigation, the issue comes from it not finding them in the pages because the standard regular expression doesn't match them.
This patch makes edx-ty try another regex when the first one doesn't return a match.