### PR TITLE
Handles "--version" argument via argparser.

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -386,16 +386,12 @@ def parse_args():
                         help='print lots of debug information')
 
     parser.add_argument('--version',
-                        dest='version',
-                        action='store_true',
-                        default=False,
+                        action='version',
+                        version=__version__,
                         help='display version and exit')
 
     args = parser.parse_args()
 
-    if args.version:
-        print(__version__)
-        sys.exit(ExitCode.OK)
 
     # Initialize the logging system first so that other functions
     # can use it right away.


### PR DESCRIPTION
## Proposed changes

Allow argparse module to handle '--version' argument so that other required parameters wont be required just to print version info.

This pull request is in response to fixing issue #451.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [x] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This is a small change. Instead of checking for version argument and displaying it with print(), allow parser to recognize the argument and take action appropriately.

### Reviewers
@rbrito For your kind review.
