### PR TITLE
travis: Test with Python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
   - "pypy"
 matrix:
   allow_failures:


### PR DESCRIPTION
This makes Travis test with Python 3.5 and 3.6.