### PR TITLE
Fixed the section parsing due to section name not being parsed properly

### DIFF
--- a/edx_dl/parsing.py
+++ b/edx_dl/parsing.py
@@ -376,7 +376,7 @@ class NewEdXPageExtractor(CurrentEdXPageExtractor):
 
         def _get_section_name(section_soup):  # FIXME: Extract from here and test
             try:
-                return section_soup.div.h3.string
+                return section_soup.find_all("h3", class_="section-title")[0].string
             except AttributeError:
                 return None
 


### PR DESCRIPTION
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

## Proposed changes

Fixing the 0 courses available error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x ] I have checked that the unit tests pass locally with my changes
- [x ] I have checked the style of the new code (lint/pep).
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)

## Further comments
Due to the new structure, the make title function was returning None. In turn, the filter for the properly parsed class was failing. I have tested my code for the EdX courses I am subscribed to, and it is working,

### Reviewers
@rbrito 
