### PR TITLE
Change mitprox switch

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -86,8 +86,8 @@ OPENEDX_SITES = {
         'url': 'http://mooc.online.gwu.edu',
         'courseware-selector': ('nav', {'aria-label': 'Course Navigation'}),
     },
-    'mitprox': {
-        'url': 'https://mitprofessionalx.mit.edu',
+    'mitxpro': {
+        'url': 'https://mitxpro.mit.edu',
         'courseware-selector': ('nav', {'aria-label': 'Course Navigation'}),
     },
     'bits':{


### PR DESCRIPTION
## Proposed changes

URL https://mitprofessionalx.mit.edu seems to redirect to https://mitxpro.mit.edu for current programs (at least).
Two changes:
- base URL for login changed to mitxpro.mit.edu from mitprofessionalx.mit.edu
- switch 'mitprox' changed to 'mitxpro', to make it consistent with (current) site name

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [ x] I have checked that the unit tests pass locally with my changes
- [ x] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
