### PR TITLE
Use filtered units instead when selecting what files to download

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -1055,10 +1055,10 @@ def main():
     # finally we download or export all the resources
     if args.export_filename is not None:
         logging.info('exporting urls to file %s', args.export_filename)
-        urls = extract_urls_from_units(all_units, args.export_format)
+        urls = extract_urls_from_units(filtered_units, args.export_format)
         save_urls_to_file(urls, args.export_filename)
     else:
-        download(args, selections, all_units, headers)
+        download(args, selections, filtered_units, headers)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

## Proposed changes

Uses filtered units when downloading instead of all units. This seem to fix #487.
 
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [-] I have checked that the unit tests pass locally with my changes 
- [-] I have checked the style of the new code (lint/pep).
- [-] I have added tests that prove my fix is effective or that my feature works
- [-] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, please explain why you chose
the solution you did and what alternatives you considered, etc.

### Reviewers
If you know the person who can review your code please add a @mention.
