### PR TITLE
adjust the name input of the SubSection to the new HTML structure

### DIFF
--- a/edx_dl/parsing.py
+++ b/edx_dl/parsing.py
@@ -388,7 +388,7 @@ class NewEdXPageExtractor(CurrentEdXPageExtractor):
             # FIXME correct extraction of subsection.name (unicode)
             subsections = [SubSection(position=i,
                                       url=s.a['href'],
-                                      name=s.a.div.span.string.strip())
+                                      name=s.a.div.div.string.strip())
                            for i, s in enumerate(subsections_soup, 1)]
 
             return subsections


### PR DESCRIPTION
Bug Fix

## Proposed changes

The code was crashing on line 391 of the file edx_dl/parsing.py
AttributeError: 'NoneType' object has no attribute 'string'. It was because the section name path changed from s.a.div.span to s.a.div.div, so I changed it accordingly.
https://github.com/coursera-dl/edx-dl/issues/514

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [x] I have checked the style of the new code (lint/pep).
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)