### PR TITLE
Added filename sanitization for non-video resources

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -686,7 +686,7 @@ def _build_filename_from_url(url, target_dir, filename_prefix):
         filename_template = filename_prefix + "-%(title)s-%(id)s.%(ext)s"
         filename = os.path.join(target_dir, filename_template)
     else:
-        original_filename = url.rsplit('/', 1)[1]
+        original_filename = clean_filename(url.rsplit('/', 1)[1])
         filename = os.path.join(target_dir,
                                 filename_prefix + '-' + original_filename)
 


### PR DESCRIPTION
This adds sanitization to filenames given to non-video resources.

At the moment filename for non-video resources is derived from resource url, which may contain non-fs-friendly characters.

For example, running:

    edx-dl --dry-run -u <username> https://courses.edx.org/courses/course-v1:MITx+18.6501x+3T2019/course/

... schedules download:
    
    ...
    [skipping] https://courses.edx.org/asset-v1:MITx+18.6501x+3T2019+type@asset+block@lectureslides_chap1_annot.pdf => Downloaded\Fundamentals_of_Statistics\02-Unit_1_Introduction_to_statistics\02-asset-v1:MITx+18.6501x+3T2019+type@asset+block@lectureslides_chap1_annot.pdf
    ...

... (note `:` character that is used in destination filename and is not fs-friendly).

This results in silent failure to download affected resources.
